### PR TITLE
Fixes required for running the multi_progress_bar project

### DIFF
--- a/lib/ffi-ncurses/ncurses.rb
+++ b/lib/ffi-ncurses/ncurses.rb
@@ -81,6 +81,19 @@ module Ncurses
       # log(:mm, 1, name)
       name = name.to_s
       if name[0,2] == "mv"
+        # This is a hack-fix to make the library work with `multi_progressbar`. The code in this
+        # method is a bit confusing.
+        # First, it's not clear if trying to add `w` to `mvwin` is correct - it seems not.
+        # Second, it's not clear which project the code is copied from ("Lifted from Ncurses"),
+        # since in the top-level ncurses library:
+        # (https://github.com/eclubb/ncurses-ruby/blob/0d15ede5a05ec5bc6e6f42fb2cb76fedadf5d554/lib/ncurses.rb#L62)
+        # the code is different.
+        #
+        if name == "mvwin"
+          FFI::NCurses.send(name, @win, *args)
+          return
+        end
+
         # log(:mm, 2, "mv")
         test_name = name.dup
         test_name[2,0] = "w" # insert "w" after"mv"


### PR DESCRIPTION
The crucial fix is the `mvwin` case, which is not handled correctly.

It's not clear if this fix is fundamentally correct, but it does the job required right now.